### PR TITLE
자료구조 수업 과제 Java8에서 7로 포팅

### DIFF
--- a/Data Stucture/Stack Calculator/CalculatorTest.java
+++ b/Data Stucture/Stack Calculator/CalculatorTest.java
@@ -83,9 +83,6 @@
 
 import java.io.*;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 
 //
@@ -383,7 +380,7 @@ class Parser {
     private HashMap<Context, Option<Context>> cache = new HashMap<Context, Option<Context>>();
     private Option<Context> _tryElement(Context ctxt) {
         final Parser self = this;
-        Function<Context, Option<Context>> compute = new Function<Context, Option<Context>>() {
+        java.util.function.Function<Context, Option<Context>> compute = new java.util.function.Function<Context, Option<Context>>() {
             @Override
             public Option<Context> apply(Context c) {
                 return or(

--- a/Data Stucture/Stack Calculator/CalculatorTest.java
+++ b/Data Stucture/Stack Calculator/CalculatorTest.java
@@ -172,7 +172,7 @@ class Parser {
                 public Option<List<Token<Type>>> apply(Context c) {
                     if (c.cursor != tokens.size()) { return Option.empty(); }
 
-                    return Option.of(c.terminate().output);
+                    return Option.<List<Token<Type>>>of(c.terminate().output);
                 }
             });
     }
@@ -185,14 +185,14 @@ class Parser {
     private Option<Token<Type>> tokenAt(int index) {
         return 0 <= index && index < tokens.size()
             ? Option.of(tokens.get(index))
-            : Option.empty();
+            : Option.<Token<Type>>empty();
     }
 
     // Missing `or` function for Option<T>
     private static <T> Option<T> or(Option<T> left, Option<T> right) {
         return left.isPresent() ? left
             : right.isPresent() ? right
-            : Option.empty();
+            : Option.<T>empty();
     }
 
     // Parser context. 파서가 파싱중 사용하는 컨텍스트 클래스이다.

--- a/Data Stucture/Stack Calculator/CalculatorTest.java
+++ b/Data Stucture/Stack Calculator/CalculatorTest.java
@@ -162,7 +162,7 @@ class Parser {
     public static Function<List<Token<Type>>, Option<List<Token<Type>>>> parse = new Function<List<Token<Type>>, Option<List<Token<Type>>>>() {
         @Override public Option<List<Token<Type>>> apply(List<Token<Type>> t) { return _parse(t); }
     };
-    private static Option<List<Token<Type>>> _parse(List<Token<Type>> tokens) {
+    private static Option<List<Token<Type>>> _parse(final List<Token<Type>> tokens) {
         Parser p = new Parser(tokens);
         Context c0 = new Context();
 
@@ -226,7 +226,7 @@ class Parser {
             @Override
             public Context apply(Token<Type> t) { return _push(t); }
         };
-        private Context _push(Token<Type> t) {
+        private Context _push(final Token<Type> t) {
             switch (t.kind) {
             case Number: {
                 final ArrayList<Token<Type>> output = new ArrayList<Token<Type>>(this.output) {{
@@ -404,7 +404,7 @@ class Parser {
         }
         return value;
     }
-    private Function<Context, Option<Context>> tryOp(String... ops) {
+    private Function<Context, Option<Context>> tryOp(final String... ops) {
         return new Function<Context, Option<Context>>() {
             @Override
             public Option<Context> apply(Context ctxt) {

--- a/Data Stucture/Stack Calculator/CalculatorTest.java
+++ b/Data Stucture/Stack Calculator/CalculatorTest.java
@@ -380,7 +380,7 @@ class Parser {
     private HashMap<Context, Option<Context>> cache = new HashMap<Context, Option<Context>>();
     private Option<Context> _tryElement(Context ctxt) {
         final Parser self = this;
-        java.util.function.Function<Context, Option<Context>> compute = new java.util.function.Function<Context, Option<Context>>() {
+        Function<Context, Option<Context>> compute = new Function<Context, Option<Context>>() {
             @Override
             public Option<Context> apply(Context c) {
                 return or(
@@ -395,7 +395,14 @@ class Parser {
         };
 
         // Memoization
-        return cache.computeIfAbsent(ctxt, compute);
+        Option<Context> value = cache.get(ctxt);
+        if (value == null) {
+            value = compute.apply(ctxt);
+            if (value != null) {
+                cache.put(ctxt, value);
+            }
+        }
+        return value;
     }
     private Function<Context, Option<Context>> tryOp(String... ops) {
         return new Function<Context, Option<Context>>() {

--- a/Data Stucture/Stack Calculator/Function.java
+++ b/Data Stucture/Stack Calculator/Function.java
@@ -1,0 +1,6 @@
+//
+// Java 1.7에 호환되도록 구현한 Function 인터페이스
+//
+public interface Function<T, R> {
+    R apply(T t);
+}

--- a/Data Stucture/Stack Calculator/Lexer.java
+++ b/Data Stucture/Stack Calculator/Lexer.java
@@ -1,5 +1,4 @@
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +22,7 @@ class Lexer<E> {
         rules.add(new Rule<E>(rule, kind));
     }
 
-    public Optional<ArrayList<Token<E>>> lex(String input) {
+    public Option<ArrayList<Token<E>>> lex(String input) {
         ArrayList<Token<E>> result = new ArrayList<Token<E>>();
 
         while (!input.isEmpty()) {
@@ -38,17 +37,17 @@ class Lexer<E> {
                 break;
             }
             // 렉싱에 실패한경우, empty 반환
-            if (failed) { return Optional.empty(); }
+            if (failed) { return Option.empty(); }
         }
 
         // 렉싱 결과물 반환
-        return Optional.of(result);
+        return Option.of(result);
     }
 }
 
 
 //
-// 토큰 클래스. 렉싱 결과를 반환할때, Optional<ArrayList<Token<E>>> 를 반환한다.
+// 토큰 클래스. 렉싱 결과를 반환할때, Option<ArrayList<Token<E>>> 를 반환한다.
 //
 class Token<E> {
     public final String sequence;

--- a/Data Stucture/Stack Calculator/Makefile
+++ b/Data Stucture/Stack Calculator/Makefile
@@ -1,7 +1,7 @@
 all: $(patsubst %.java, %.class, $(wildcard *.java))
 
 %.class: %.java
-	javac $< -Xdiags:verbose -Xlint:unchecked
+	javac $< -Xlint:unchecked
 
 .PHONY: run test clean
 run: all

--- a/Data Stucture/Stack Calculator/Option.java
+++ b/Data Stucture/Stack Calculator/Option.java
@@ -1,0 +1,50 @@
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+//
+// Java 1.7에 호환되도록 구현한 모나딕 Option 타입
+//
+// Reference:
+//   https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
+//
+public final class Option<T> {
+    private final T data;
+    private Option() { data = null; }
+    private Option(T data) { this.data = Objects.requireNonNull(data); }
+
+    private static final Option<?> EMPTY = new Option<>();
+    public static <E> Option<E> empty() {
+        @SuppressWarnings("unchecked")
+        Option<E> t = (Option<E>) EMPTY;
+        return t;
+    }
+    public static <E> Option<E> of(E data) {
+        return new Option<E>(data);
+    }
+    public static <E> Option<E> ofNullable(E value) {
+        return value == null ? Option.<E>empty() : of(value);
+    }
+
+    public boolean isPresent() { return data != null; }
+
+    public T orElse(T other) { return data != null ? data : other; }
+
+    public Option<T> filter(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate);
+        if (!isPresent()) { return this; }
+        return predicate.test(data) ? this : Option.<T>empty();
+    }
+
+    public <E> Option<E> map(Function<? super T, ? extends E> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) { return empty(); }
+        return Option.ofNullable(mapper.apply(data));
+    }
+
+    public <E> Option<E> flatMap(Function<? super T, Option<E>> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) { return empty(); }
+        return Objects.requireNonNull(mapper.apply(data));
+    }
+}

--- a/Data Stucture/Stack Calculator/Option.java
+++ b/Data Stucture/Stack Calculator/Option.java
@@ -1,6 +1,4 @@
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 //
 // Java 1.7에 호환되도록 구현한 모나딕 Option 타입

--- a/Data Stucture/Stack Calculator/Predicate.java
+++ b/Data Stucture/Stack Calculator/Predicate.java
@@ -1,0 +1,6 @@
+//
+// Java 1.7에 호환되도록 구현한 Predicate 인터페이스
+//
+public interface Predicate<T> {
+    boolean test(T t);
+}


### PR DESCRIPTION
자료구조 3번 과제를 처음엔 Java 8 로 코딩했었는데, 학교에서 Java 7 이 아니면 받지 않겠다고 하여서 자바 7으로 포팅함

1. 없는 컴파일옵션 제거
2. `Optional<T>`, `Function<T>`, `Predicate<T>`, `Map<T>#computeIfAbsent` 구현
3. Lambda expression, first class function desugar
4. 자바 8 타입추론에 의존하는 코드 제거
5. 클로저가 참조하는 변수들에 모두 `final` 키워드를 붙임